### PR TITLE
reform builder APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,8 @@ hyperx = "0.12.0"
 cookie = { version = "0.10.1", features = ["percent-encode"] }
 serde = { version = "1.0.66", features = ["derive"] }
 serde_json = "1.0.20"
+state = "0.4"
+indexmap = "1.0.1"
 
 #tsukuyomi-codegen = { version = "0.1.0", path = "codegen", optional = true }
 

--- a/src/app/endpoint.rs
+++ b/src/app/endpoint.rs
@@ -12,7 +12,7 @@ use super::uri::Uri;
 pub struct Endpoint {
     pub(super) uri: Uri,
     pub(super) method: Method,
-    pub(super) scope_id: usize,
+    pub(super) scope_id: Option<usize>,
     pub(super) handler: Handler,
 }
 
@@ -27,7 +27,7 @@ impl Endpoint {
         &self.method
     }
 
-    pub(crate) fn scope_id(&self) -> usize {
+    pub(crate) fn scope_id(&self) -> Option<usize> {
         self.scope_id
     }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -51,9 +51,7 @@ impl Handler {
     ///
     /// # fn main() -> tsukuyomi::AppResult<()> {
     /// let app = App::builder()
-    ///     .mount("/", |m| {
-    ///         m.get("/index.html").handle(Handler::new_ready(index));
-    ///     })
+    ///     .route(("/index.html", Handler::new_ready(index)))
     ///     .finish()?;
     /// # Ok(())
     /// # }
@@ -91,9 +89,7 @@ impl Handler {
     ///
     /// # fn main() -> tsukuyomi::AppResult<()> {
     /// let app = App::builder()
-    ///     .mount("/", |m| {
-    ///         m.get("/posts").handle(Handler::new_async(handler));
-    ///     })
+    ///     .route(("/posts", Handler::new_async(handler)))
     ///     .finish()?;
     /// # Ok(())
     /// # }
@@ -142,9 +138,7 @@ impl Handler {
     ///
     /// # fn main() -> tsukuyomi::AppResult<()> {
     /// let app = App::builder()
-    ///     .mount("/", |m| {
-    ///         m.get("/posts").handle(Handler::new_fully_async(handler));
-    ///     })
+    ///     .route(("/posts", Handler::new_fully_async(handler)))
     ///     .finish()?;
     /// # Ok(())
     /// # }

--- a/src/input/input.rs
+++ b/src/input/input.rs
@@ -175,7 +175,7 @@ impl<'task> Input<'task> {
         T: Send + Sync + 'static,
     {
         let endpoint = self.endpoint();
-        self.app.states().get(endpoint.scope_id())
+        self.app.get(endpoint.scope_id())
     }
 
     /// Returns a proxy object for managing the value of Cookie entries.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,12 +20,14 @@ extern crate futures;
 extern crate http;
 extern crate hyper;
 extern crate hyperx;
+extern crate indexmap;
 #[macro_use]
 extern crate log;
 extern crate mime;
 extern crate serde;
 #[macro_use]
 extern crate serde_json;
+extern crate state;
 extern crate tokio;
 extern crate tokio_tcp;
 extern crate tokio_threadpool;

--- a/src/local.rs
+++ b/src/local.rs
@@ -11,9 +11,7 @@
 //! use tsukuyomi::local::LocalServer;
 //!
 //! let app = App::builder()
-//!     .mount("/", |m| {
-//!         m.get("/hello").handle(Handler::new_ready(|_| "Hello"));
-//!     })
+//!     .route(("/hello", Handler::new_ready(|_| "Hello")))
 //!     .finish()
 //!     .unwrap();
 //!

--- a/src/modifier.rs
+++ b/src/modifier.rs
@@ -28,13 +28,13 @@
 //!     }
 //! }
 //!
+//! # fn main() -> tsukuyomi::AppResult<()> {
 //! let app = App::builder()
-//!     .mount("/", |m| {
-//!         m.get("/").handle(Handler::new_ready(|_| "Hello"));
-//!     })
+//!     .route(("/", Handler::new_ready(|_| "Hello")))
 //!     .modifier(RequestCounter::default())    // <--
-//!     .finish()
-//!     .unwrap();
+//!     .finish()?;
+//! # Ok(())
+//! # }
 //! ```
 
 use futures::{self, Future, Poll};

--- a/tests/test_modifier.rs
+++ b/tests/test_modifier.rs
@@ -78,9 +78,7 @@ fn single_empty_modifier() {
     let handle = Marker::default();
 
     let app = App::builder()
-        .mount("/", |m| {
-            m.get("/").handle(handler(&handle));
-        })
+        .route(("/", handler(&handle)))
         .modifier(EmptyModifier {
             before: before.clone(),
             after: after.clone(),
@@ -104,9 +102,7 @@ fn single_before_done_modifier() {
     let handle = Marker::default();
 
     let app = App::builder()
-        .mount("/", |m| {
-            m.get("/").handle(handler(&handle));
-        })
+        .route(("/", handler(&handle)))
         .modifier(BeforeDoneModifier {
             before: before.clone(),
             after: after.clone(),
@@ -134,9 +130,7 @@ fn multiple_empty_modifier() {
     let handle = Marker::default();
 
     let app = App::builder()
-        .mount("/", |m| {
-            m.get("/").handle(handler(&handle));
-        })
+        .route(("/", handler(&handle)))
         .modifier(EmptyModifier {
             before: before1.clone(),
             after: after1.clone(),
@@ -174,9 +168,7 @@ fn empty_and_before_done_modifier_1() {
     let handle = Marker::default();
 
     let app = App::builder()
-        .mount("/", |m| {
-            m.get("/").handle(handler(&handle));
-        })
+        .route(("/", handler(&handle)))
         .modifier(EmptyModifier {
             before: before1.clone(),
             after: after1.clone(),
@@ -208,9 +200,7 @@ fn empty_and_before_done_modifier_2() {
     let handle = Marker::default();
 
     let app = App::builder()
-        .mount("/", |m| {
-            m.get("/").handle(handler(&handle));
-        })
+        .route(("/", handler(&handle)))
         .modifier(BeforeDoneModifier {
             before: before1.clone(),
             after: after1.clone(),


### PR DESCRIPTION
* remove some supplemental methods (`get`, `post`, etc) from `Route`
* add support for adding routes to the root (without `mount`)
* improve ergonomics when adding routes