### PR TITLE
add parameter 'preset' to the custom derive IntoResponse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,6 +2123,7 @@ version = "0.5.1"
 dependencies = [
  "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "tsukuyomi 0.5.1",
 ]

--- a/examples/cors/src/main.rs
+++ b/examples/cors/src/main.rs
@@ -11,7 +11,7 @@ use {
 };
 
 #[derive(Debug, Deserialize, Serialize, IntoResponse)]
-#[response(with = "tsukuyomi::output::into_response::json")]
+#[response(preset = "tsukuyomi::output::preset::Json")]
 struct UserInfo {
     username: String,
     email: String,

--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -10,7 +10,7 @@ use {
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize, IntoResponse)]
-#[response(with = "tsukuyomi::output::into_response::json")]
+#[response(preset = "tsukuyomi::output::preset::Json")]
 struct User {
     name: String,
     age: u32,

--- a/tsukuyomi/macros/Cargo.toml
+++ b/tsukuyomi/macros/Cargo.toml
@@ -17,3 +17,4 @@ proc-macro2 = "0.4.20"
 
 [dev-dependencies]
 tsukuyomi = { version = "0.5", path = ".." }
+serde = { version = "1", features = ["derive"] }

--- a/tsukuyomi/macros/src/derive_into_response.rs
+++ b/tsukuyomi/macros/src/derive_into_response.rs
@@ -30,6 +30,7 @@ enum InputKind {
     Struct(Target),
     Enum(Vec<Variant>),
     ExplicitWithFnPath(syn::Path),
+    UsePreset(syn::Path),
 }
 
 #[derive(Debug)]
@@ -82,8 +83,12 @@ mod parsing {
         fn parse(input: parse::ParseStream<'_>) -> parse::Result<Self> {
             let input: syn::DeriveInput = input.parse()?;
 
+            // The kind when specifying the path to `into_response` explicitly.
             enum ExplicitKind {
+                // Old style - free function with the same sigunature as `IntoResponse::into_response`
                 Fn(syn::Path),
+                // New style - a type that implements Preset<T>
+                Preset(syn::Path),
             }
 
             let mut explicit_path: Option<ExplicitKind> = None;
@@ -112,11 +117,21 @@ mod parsing {
                                 if explicit_path.is_some() {
                                     return Err(parse_error_at(
                                         &pair,
-                                        "the parameter 'with' has already been set",
+                                        "the parameter 'with' or 'preset' has already been provided",
                                     ));
                                 }
                                 let path = parse_literal(&pair.lit)?;
                                 explicit_path = Some(ExplicitKind::Fn(path));
+                            }
+                            "preset" => {
+                                if explicit_path.is_some() {
+                                    return Err(parse_error_at(
+                                        &pair,
+                                        "the parameter 'with' or 'preset' has already been provided",
+                                    ));
+                                }
+                                let path = parse_literal(&pair.lit)?;
+                                explicit_path = Some(ExplicitKind::Preset(path));
                             }
                             "bound" => {
                                 let bound = parse_literal(&pair.lit)?;
@@ -135,6 +150,7 @@ mod parsing {
 
             let kind = match explicit_path {
                 Some(ExplicitKind::Fn(path)) => InputKind::ExplicitWithFnPath(path),
+                Some(ExplicitKind::Preset(path)) => InputKind::UsePreset(path),
                 None => match input.data {
                     syn::Data::Struct(data) => {
                         let field = match data.fields {
@@ -233,6 +249,8 @@ impl<'a> Context<'a> {
         let IntoResponse: syn::Path = syn::parse_quote!(tsukuyomi::output::internal::IntoResponse);
         let Request: syn::Path = syn::parse_quote!(tsukuyomi::output::internal::Request);
         let Response: syn::Path = syn::parse_quote!(tsukuyomi::output::internal::Response);
+        let Preset: syn::Path = syn::parse_quote!(tsukuyomi::output::internal::Preset);
+
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
 
         // appends additional bounds specified by the macro user to where clause.
@@ -260,6 +278,20 @@ impl<'a> Context<'a> {
                 )
             }
 
+            InputKind::UsePreset(path) => {
+                where_clause
+                    .get_or_insert_with(|| syn::WhereClause {
+                        where_token: Default::default(),
+                        predicates: Default::default(),
+                    })
+                    .predicates
+                    .push(syn::parse_quote!(#path: #Preset<Self>));
+
+                Body = syn::parse_quote!(<#path as #Preset<Self>>::Body);
+                Error = syn::parse_quote!(<#path as #Preset<Self>>::Error);
+                body = quote!(< #path as #Preset<Self> >::into_response(self, request));
+            }
+
             InputKind::Struct(target) => match target {
                 Target::Unit | Target::UnnamedField(None) | Target::NamedField(None) => {
                     Body = syn::parse_quote!(<() as #IntoResponse>::Body);
@@ -268,8 +300,14 @@ impl<'a> Context<'a> {
                 }
 
                 Target::UnnamedField(Some(field)) => {
-                    append_into_response_bound(&mut where_clause, field, &IntoResponse);
                     let bounded_ty = &field.ty;
+                    where_clause
+                        .get_or_insert_with(|| syn::WhereClause {
+                            where_token: Default::default(),
+                            predicates: Default::default(),
+                        })
+                        .predicates
+                        .push(syn::parse_quote!(#bounded_ty: #IntoResponse));
                     Body = syn::parse_quote!(<#bounded_ty as #IntoResponse>::Body);
                     Error = syn::parse_quote!(<#bounded_ty as #IntoResponse>::Error);
                     body = quote!(match self {
@@ -278,9 +316,15 @@ impl<'a> Context<'a> {
                 }
 
                 Target::NamedField(Some(field)) => {
-                    append_into_response_bound(&mut where_clause, field, &IntoResponse);
-                    let field_ident = &field.ident;
                     let bounded_ty = &field.ty;
+                    let field_ident = &field.ident;
+                    where_clause
+                        .get_or_insert_with(|| syn::WhereClause {
+                            where_token: Default::default(),
+                            predicates: Default::default(),
+                        })
+                        .predicates
+                        .push(syn::parse_quote!(#bounded_ty: #IntoResponse));
                     Body = syn::parse_quote!(<#bounded_ty as #IntoResponse>::Body);
                     Error = syn::parse_quote!(<#bounded_ty as #IntoResponse>::Error);
                     body = quote!(match self {
@@ -305,7 +349,14 @@ impl<'a> Context<'a> {
                                 .map_err(Into::into))
                         }
                         Target::UnnamedField(Some(field)) => {
-                            append_into_response_bound(&mut  where_clause, field, &IntoResponse);
+                            let bounded_ty = &field.ty;
+                            where_clause
+                                .get_or_insert_with(|| syn::WhereClause {
+                                    where_token: Default::default(),
+                                    predicates: Default::default(),
+                                })
+                                .predicates
+                                .push(syn::parse_quote!(#bounded_ty: #IntoResponse));
                             quote!(#Self_ :: #Variant (__arg_0) => #IntoResponse::into_response(__arg_0, request)
                                 .map(|response| response.map(Into::into))
                                 .map_err(Into::into))
@@ -317,7 +368,14 @@ impl<'a> Context<'a> {
                                 .map_err(Into::into))
                         }
                         Target::NamedField(Some(field)) => {
-                            append_into_response_bound(&mut  where_clause, field, &IntoResponse);
+                            let bounded_ty = &field.ty;
+                            where_clause
+                                .get_or_insert_with(|| syn::WhereClause {
+                                    where_token: Default::default(),
+                                    predicates: Default::default(),
+                                })
+                                .predicates
+                                .push(syn::parse_quote!(#bounded_ty: #IntoResponse));
                             let field = &field.ident;
                             quote!(#Self_ :: #Variant { #field: __arg_0, } => #IntoResponse::into_response(__arg_0, request)
                                 .map(|response| response.map(Into::into))
@@ -355,33 +413,6 @@ impl<'a> Context<'a> {
             }
         )
     }
-}
-
-#[allow(nonstandard_style)]
-fn append_into_response_bound(
-    where_clause: &mut Option<syn::WhereClause>,
-    field: &syn::Field,
-    IntoResponse: &syn::Path,
-) {
-    where_clause
-        .get_or_insert_with(|| syn::WhereClause {
-            where_token: Default::default(),
-            predicates: Default::default(),
-        })
-        .predicates
-        .push(syn::WherePredicate::Type(syn::PredicateType {
-            lifetimes: None,
-            bounded_ty: field.ty.clone(),
-            colon_token: Default::default(),
-            bounds: vec![syn::TypeParamBound::Trait(syn::TraitBound {
-                paren_token: None,
-                modifier: syn::TraitBoundModifier::None,
-                lifetimes: None,
-                path: IntoResponse.clone(),
-            })]
-            .into_iter()
-            .collect(),
-        }));
 }
 
 // ==== test ====
@@ -607,7 +638,7 @@ mod tests {
     }
 
     t! {
-        name: explicit_struct,
+        name: explicit_with_fn,
         source: {
             #[response(with = "my::into_response")]
             struct A {
@@ -637,7 +668,7 @@ mod tests {
     }
 
     t! {
-        name: explicit_with_additional_bounds,
+        name: explicit_with_fn_additional_bounds,
         source: {
             #[response(
                 with = "my::into_response",
@@ -669,6 +700,74 @@ mod tests {
                     my::into_response(self, request)
                         .map(|response| response.map(Into::into))
                         .map_err(Into::into)
+                }
+            }
+        },
+    }
+
+    t! {
+        name: explicit_preset,
+        source: {
+            #[response(preset = "my::Preset")]
+            struct A {
+                x: X,
+                y: Y,
+            }
+        },
+        expected: {
+            impl tsukuyomi::output::internal::IntoResponse for A
+            where
+                my::Preset: tsukuyomi::output::internal::Preset<Self>,
+            {
+                type Body = <my::Preset as tsukuyomi::output::internal::Preset<Self> >::Body;
+                type Error = <my::Preset as tsukuyomi::output::internal::Preset<Self> >::Error;
+
+                #[inline]
+                fn into_response(
+                    self,
+                    request: &tsukuyomi::output::internal::Request<()>
+                ) -> Result<
+                    tsukuyomi::output::internal::Response<Self::Body>,
+                    Self::Error
+                > {
+                    <my::Preset as tsukuyomi::output::internal::Preset<Self> >::into_response(self, request)
+                }
+            }
+        },
+    }
+
+    t! {
+        name: explicit_preset_additional_bounds,
+        source: {
+            #[response(
+                preset = "my::Preset",
+                bound = "X: Foo",
+                bound = "Y: Foo",
+            )]
+            struct A<X, Y> {
+                x: X,
+                y: Y,
+            }
+        },
+        expected: {
+            impl<X, Y> tsukuyomi::output::internal::IntoResponse for A<X, Y>
+            where
+                X: Foo,
+                Y: Foo,
+                my::Preset: tsukuyomi::output::internal::Preset<Self>,
+            {
+                type Body = <my::Preset as tsukuyomi::output::internal::Preset<Self> >::Body;
+                type Error = <my::Preset as tsukuyomi::output::internal::Preset<Self> >::Error;
+
+                #[inline]
+                fn into_response(
+                    self,
+                    request: &tsukuyomi::output::internal::Request<()>
+                ) -> Result<
+                    tsukuyomi::output::internal::Response<Self::Body>,
+                    Self::Error
+                > {
+                    <my::Preset as tsukuyomi::output::internal::Preset<Self> >::into_response(self, request)
                 }
             }
         },
@@ -724,4 +823,20 @@ mod tests {
         error: "multiple fields is not supported.",
     }
 
+    t! {
+        name: failcase_duplicate_with_and_preset,
+        source: {
+            #[response(
+                with = "path::to::into_response",
+                preset = "path::to::Preset",
+            )]
+            enum A {
+                B {
+                    c: C,
+                    d: D,
+                },
+            }
+        },
+        error: "the parameter 'with' or 'preset' has already been provided",
+    }
 }

--- a/tsukuyomi/macros/src/lib.rs
+++ b/tsukuyomi/macros/src/lib.rs
@@ -4,6 +4,7 @@
 #![deny(nonstandard_style, rust_2018_idioms, rust_2018_compatibility, unused)]
 #![cfg_attr(test, deny(warnings))]
 #![forbid(clippy::unimplemented)]
+#![doc(test(attr(deny(deprecated))))]
 
 extern crate proc_macro;
 

--- a/tsukuyomi/src/output.rs
+++ b/tsukuyomi/src/output.rs
@@ -205,6 +205,7 @@ impl IntoResponse for &'static str {
     type Error = Never;
 
     #[inline]
+    #[allow(deprecated)]
     fn into_response(self, request: &Request<()>) -> Result<Response<Self::Body>, Self::Error> {
         self::into_response::plain(self, request)
     }
@@ -215,6 +216,7 @@ impl IntoResponse for String {
     type Error = Never;
 
     #[inline]
+    #[allow(deprecated)]
     fn into_response(self, request: &Request<()>) -> Result<Response<Self::Body>, Self::Error> {
         self::into_response::plain(self, request)
     }
@@ -262,6 +264,7 @@ where
 }
 
 /// Creates a JSON responder from the specified data.
+#[allow(deprecated)]
 #[inline]
 pub fn json<T>(data: T) -> impl IntoResponse<Body = Vec<u8>, Error = Error>
 where
@@ -271,6 +274,7 @@ where
 }
 
 /// Creates a JSON responder with pretty output from the specified data.
+#[allow(deprecated)]
 #[inline]
 pub fn json_pretty<T>(data: T) -> impl IntoResponse<Body = Vec<u8>, Error = Error>
 where
@@ -280,6 +284,7 @@ where
 }
 
 /// Creates an HTML responder with the specified response body.
+#[allow(deprecated)]
 #[inline]
 pub fn html<T>(body: T) -> impl IntoResponse<Body = T, Error = Never>
 where
@@ -379,7 +384,11 @@ pub mod preset {
     }
 }
 
-#[allow(missing_docs)]
+#[doc(hidden)]
+#[deprecated(
+    since = "0.5.2",
+    note = "this module will be removed in the next version."
+)]
 pub mod into_response {
     use {
         super::ResponseBody,

--- a/tsukuyomi/tests/integration_tests/macros.rs
+++ b/tsukuyomi/tests/integration_tests/macros.rs
@@ -98,6 +98,7 @@ mod responder {
         }
     }
 
+    #[allow(deprecated)]
     #[test]
     fn test_into_response_explicit_fn() -> tsukuyomi_server::Result<()> {
         #[derive(tsukuyomi::output::IntoResponse)]

--- a/tsukuyomi/tests/integration_tests/macros.rs
+++ b/tsukuyomi/tests/integration_tests/macros.rs
@@ -99,7 +99,7 @@ mod responder {
     }
 
     #[test]
-    fn test_responder() -> tsukuyomi_server::Result<()> {
+    fn test_into_response_explicit_fn() -> tsukuyomi_server::Result<()> {
         #[derive(tsukuyomi::output::IntoResponse)]
         #[response(with = "self::sub::display")]
         struct Foo(String);
@@ -112,6 +112,77 @@ mod responder {
 
         #[derive(tsukuyomi::output::IntoResponse)]
         #[response(with = "self::sub::display", bound = "T: fmt::Display")]
+        struct Bar<T>(T);
+
+        impl<T: fmt::Display> fmt::Display for Bar<T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt::Display::fmt(&self.0, f)
+            }
+        }
+
+        let app = App::create(chain! {
+            path!("/foo") //
+                .to(endpoint::call(|| Foo("Foo".into()))),
+            path!("/bar") //
+                .to(endpoint::call(|| Bar("Bar")))
+        })?;
+
+        let mut server = tsukuyomi_server::test::server(app)?;
+
+        let response = server.perform("/foo")?;
+        assert_eq!(response.status(), 200);
+        assert_eq!(
+            response.header("content-type")?,
+            "text/plain; charset=utf-8"
+        );
+        assert_eq!(response.body().to_utf8()?, "Foo");
+
+        let response = server.perform("/bar")?;
+        assert_eq!(response.body().to_utf8()?, "Bar");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_into_response_preset() -> tsukuyomi_server::Result<()> {
+        use {
+            http::{Request, Response},
+            std::fmt,
+            tsukuyomi::output::preset::Preset,
+        };
+
+        struct Display;
+
+        impl<T> Preset<T> for Display
+        where
+            T: std::fmt::Display,
+        {
+            type Body = String;
+            type Error = tsukuyomi::util::Never;
+
+            fn into_response(
+                this: T,
+                _: &Request<()>,
+            ) -> Result<Response<Self::Body>, Self::Error> {
+                Ok(Response::builder()
+                    .header("content-type", "text/plain; charset=utf-8")
+                    .body(this.to_string())
+                    .unwrap())
+            }
+        }
+
+        #[derive(tsukuyomi::output::IntoResponse)]
+        #[response(preset = "Display")]
+        struct Foo(String);
+
+        impl fmt::Display for Foo {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                self.0.fmt(f)
+            }
+        }
+
+        #[derive(tsukuyomi::output::IntoResponse)]
+        #[response(preset = "Display", bound = "T: fmt::Display")]
         struct Bar<T>(T);
 
         impl<T: fmt::Display> fmt::Display for Bar<T> {


### PR DESCRIPTION
In the previous method using `with = ".."`, that takes the path to a free function with the same signature as `IntoResponse::into_response`, it was impossible to properly set the associated type since the information about the specified function is unknown.

This PR introduces a new trait `Preset<T>` that contains information necessary for code generation, and a parameter 'preset = ".."' to the custom derive `IntoResponse` to specify the code generation using this trait.