### PR TITLE
switch to the new App API: Take1

### DIFF
--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -1,14 +1,15 @@
 use tsukuyomi::{
-    config::prelude::*, //
+    endpoint::builder as endpoint, //
     server::Server,
     App,
 };
 
 fn main() -> Result<(), exitfailure::ExitFailure> {
-    let app = App::create(
-        path!("/") //
-            .to(endpoint::reply("Hello, world!\n")),
-    )?;
+    let app = App::build(|s| {
+        s.at("/", (), {
+            endpoint::reply("Hello, world!\n") //
+        })
+    })?;
 
     let mut server = Server::new(app)?;
 

--- a/examples/http-proxy/src/main.rs
+++ b/examples/http-proxy/src/main.rs
@@ -7,7 +7,7 @@ use {
     crate::proxy::Client, //
     futures::prelude::*,
     tsukuyomi::{
-        config::prelude::*, //
+        endpoint::builder as endpoint, //
         server::Server,
         App,
     },
@@ -17,19 +17,24 @@ fn main() -> Result<(), exitfailure::ExitFailure> {
     let proxy_client =
         std::sync::Arc::new(crate::proxy::proxy_client(reqwest::r#async::Client::new()));
 
-    let app = App::create(chain![
-        path!("/") //
-            .to(endpoint::any()
+    let app = App::build(|s| {
+        s.at("/", (), {
+            endpoint::any()
                 .extract(proxy_client.clone())
-                .call_async(|client: Client| client
-                    .send_forwarded_request("http://www.example.com")
-                    .and_then(|resp| resp.receive_all()))),
-        path!("/streaming") //
-            .to(endpoint::any()
+                .call_async(|client: Client| {
+                    client
+                        .send_forwarded_request("http://www.example.com")
+                        .and_then(|resp| resp.receive_all())
+                })
+        })?;
+        s.at("/streaming", (), {
+            endpoint::any()
                 .extract(proxy_client)
-                .call_async(|client: Client| client
-                    .send_forwarded_request("https://www.rust-lang.org/en-US/"))),
-    ])?;
+                .call_async(|client: Client| {
+                    client.send_forwarded_request("https://www.rust-lang.org/en-US/")
+                })
+        })
+    })?;
 
     let mut server = Server::new(app)?;
     server.bind("127.0.0.1:4000")?;

--- a/examples/json/src/main.rs
+++ b/examples/json/src/main.rs
@@ -2,7 +2,8 @@ use {
     exitfailure::ExitFailure,
     serde::{Deserialize, Serialize},
     tsukuyomi::{
-        config::prelude::*, //
+        chain,
+        endpoint::builder as endpoint,
         extractor,
         output::{Json, Responder},
         server::Server,
@@ -18,9 +19,9 @@ struct User {
 }
 
 fn main() -> Result<(), ExitFailure> {
-    let app = App::create(
-        path!("/") //
-            .to(chain![
+    let app = App::build(|s| {
+        s.at("/", (), {
+            chain![
                 endpoint::get().reply(User {
                     name: "Sakura Kinomoto".into(),
                     age: 13,
@@ -28,8 +29,9 @@ fn main() -> Result<(), ExitFailure> {
                 endpoint::post()
                     .extract(extractor::body::json())
                     .call(|user: User| user),
-            ]),
-    )?;
+            ]
+        })
+    })?;
 
     let mut server = Server::new(app)?;
     server.bind("127.0.0.1:4000")?;

--- a/examples/logging/src/main.rs
+++ b/examples/logging/src/main.rs
@@ -1,5 +1,5 @@
 use tsukuyomi::{
-    config::prelude::*, //
+    endpoint::builder as endpoint, //
     server::Server,
     vendor::http::StatusCode,
     App,
@@ -11,13 +11,17 @@ fn main() -> Result<(), exitfailure::ExitFailure> {
 
     let log = logging::log("request_logging");
 
-    let app = App::create(
-        chain![
-            path!("/").to(endpoint::get().reply("Hello.")),
-            path!("*").to(endpoint::reply(StatusCode::NOT_FOUND))
-        ]
-        .modify(log),
-    )?;
+    let app = App::build(|s| {
+        s.with(&log, |s| {
+            s.at("/", (), {
+                endpoint::get() //
+                    .reply("Hello.")
+            })?;
+            s.default((), {
+                endpoint::reply(StatusCode::NOT_FOUND) //
+            })
+        })
+    })?;
 
     let mut server = Server::new(app)?;
     log::info!("Listening on http://127.0.0.1:4000");

--- a/examples/staticfile/src/main.rs
+++ b/examples/staticfile/src/main.rs
@@ -1,7 +1,7 @@
 use {
     exitfailure::ExitFailure,
     tsukuyomi::{
-        config::prelude::*, //
+        endpoint::builder as endpoint,
         fs::{NamedFile, Staticfiles},
         server::Server,
         App,
@@ -11,12 +11,14 @@ use {
 fn main() -> Result<(), ExitFailure> {
     let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
 
-    let app = App::create(chain![
-        path!("/") //
-            .to(endpoint::get() //
-                .reply(NamedFile::open(manifest_dir.join("static/index.html")))),
-        Staticfiles::new(manifest_dir.join("static")),
-    ])?;
+    let app = App::build(|s| {
+        s.at("/", (), {
+            endpoint::get() //
+                .reply(NamedFile::open(manifest_dir.join("static/index.html")))
+        })?;
+
+        s.add(Staticfiles::new(manifest_dir.join("static")))
+    })?;
 
     let mut server = Server::new(app)?;
     server.bind("127.0.0.1:4000")?;

--- a/examples/template-askama/src/main.rs
+++ b/examples/template-askama/src/main.rs
@@ -1,12 +1,7 @@
 use {
     askama::Template,
     exitfailure::ExitFailure,
-    tsukuyomi::{
-        config::prelude::*, //
-        server::Server,
-        App,
-        Responder,
-    },
+    tsukuyomi::{endpoint::builder as endpoint, path, server::Server, App, Responder},
 };
 
 #[derive(Template, Responder)]
@@ -17,10 +12,11 @@ struct Index {
 }
 
 fn main() -> Result<(), ExitFailure> {
-    let app = App::create(
-        path!("/:name") //
-            .to(endpoint::call(|name| Index { name })),
-    )?;
+    let app = App::build(|s| {
+        s.at(path!("/:name"), (), {
+            endpoint::call(|name| Index { name }) //
+        })
+    })?;
 
     let mut server = Server::new(app)?;
     server.bind("127.0.0.1:4000")?;

--- a/examples/template-tera/src/main.rs
+++ b/examples/template-tera/src/main.rs
@@ -2,11 +2,7 @@ use {
     crate::support_tera::{Template, WithTera},
     exitfailure::ExitFailure,
     serde::Serialize,
-    tsukuyomi::{
-        config::prelude::*, //
-        server::Server,
-        App,
-    },
+    tsukuyomi::{endpoint::builder as endpoint, path, server::Server, App},
 };
 
 #[derive(Debug, Serialize)]
@@ -23,11 +19,11 @@ impl Template for Index {
 fn main() -> Result<(), ExitFailure> {
     let engine = tera::compile_templates!(concat!(env!("CARGO_MANIFEST_DIR"), "/templates/**/*"));
 
-    let app = App::create(
-        path!("/:name")
-            .to(endpoint::call(|name| Index { name }))
-            .modify(WithTera::from(engine)),
-    )?; //
+    let app = App::build(|s| {
+        s.at(path!("/:name"), WithTera::from(engine), {
+            endpoint::call(|name| Index { name }) //
+        })
+    })?;
 
     let mut server = Server::new(app)?;
     server.bind("127.0.0.1:4000")?;

--- a/tsukuyomi-askama/tests/test_askama.rs
+++ b/tsukuyomi-askama/tests/test_askama.rs
@@ -2,10 +2,9 @@ use {
     askama::Template,
     http::{header::CONTENT_TYPE, StatusCode},
     tsukuyomi::{
-        config::prelude::*, //
+        endpoint::builder as endpoint,
         test::{self, loc, TestServer},
-        App,
-        Responder,
+        App, Responder,
     },
 };
 
@@ -23,12 +22,12 @@ fn test_template_derivation() -> test::Result {
         name: &'static str,
     }
 
-    let app = App::create(
-        path!("/") //
-            .to(endpoint::get() //
-                .call(|| Index { name: "Alice" })),
-    )?;
-
+    let app = App::build(|s| {
+        s.at("/", (), {
+            endpoint::get() //
+                .call(|| Index { name: "Alice" })
+        })
+    })?;
     let mut server = TestServer::new(app)?;
     let mut client = server.connect();
 
@@ -49,12 +48,12 @@ fn test_template_with_modifier() -> test::Result {
         name: &'static str,
     }
 
-    let app = App::create(
-        path!("/") //
-            .to(endpoint::get() //
-                .call(|| Index { name: "Alice" }))
-            .modify(tsukuyomi_askama::renderer()),
-    )?;
+    let app = App::build(|s| {
+        s.at("/", tsukuyomi_askama::renderer(), {
+            endpoint::get() //
+                .call(|| Index { name: "Alice" })
+        })
+    })?;
 
     let mut server = TestServer::new(app)?;
     let mut client = server.connect();

--- a/tsukuyomi-tungstenite/tests/test_tungstenite.rs
+++ b/tsukuyomi-tungstenite/tests/test_tungstenite.rs
@@ -13,7 +13,7 @@ use {
         Request, StatusCode,
     },
     tsukuyomi::{
-        config::prelude::*, //
+        endpoint::builder as endpoint,
         test::{self, loc, TestServer},
         App,
     },
@@ -27,12 +27,13 @@ fn test_version_sync() {
 
 #[test]
 fn test_handshake() -> test::Result {
-    let app = App::create(
-        path!("/ws") //
-            .to(endpoint::get()
+    let app = App::build(|s| {
+        s.at("/ws", (), {
+            endpoint::get()
                 .extract(tsukuyomi_tungstenite::ws())
-                .call(|ws: Ws| ws.finish(|_| Ok::<(), std::io::Error>(())))),
-    )?;
+                .call(|ws: Ws| ws.finish(|_| Ok::<(), std::io::Error>(())))
+        })
+    })?;
     let mut server = TestServer::new(app)?;
     let mut client = server.connect();
 

--- a/tsukuyomi/src/app.rs
+++ b/tsukuyomi/src/app.rs
@@ -2,6 +2,8 @@
 
 pub mod concurrency;
 pub mod config;
+pub mod path;
+
 mod recognizer;
 mod scope;
 mod service;

--- a/tsukuyomi/src/app/config.rs
+++ b/tsukuyomi/src/app/config.rs
@@ -1,12 +1,12 @@
 use {
     super::{
         concurrency::{current_thread::CurrentThread, Concurrency, DefaultConcurrency},
+        path::{IntoPath, Path, RouteHandler},
         recognizer::Recognizer,
         scope::{ScopeId, Scopes},
         App, AppInner, Endpoint, ScopeData, Uri,
     },
     crate::{
-        config::path::{IntoPath, Path, RouteHandler},
         handler::{Handler, ModifyHandler},
         util::{Chain, Never},
     },
@@ -53,6 +53,7 @@ impl error::Error for Error {
 
 impl App {
     /// Creates a new `App` from the provided configuration.
+    #[deprecated]
     pub fn create(config: impl Config<()>) -> Result<Self> {
         App::create_imp(config)
     }
@@ -60,6 +61,7 @@ impl App {
 
 impl App<CurrentThread> {
     /// Creates a new `App` from the provided configuration, without guarantees of thread safety.
+    #[deprecated]
     pub fn create_local(config: impl Config<(), CurrentThread>) -> Result<Self> {
         App::create_imp(config)
     }
@@ -115,7 +117,17 @@ where
     C: Concurrency,
 {
     /// Adds a route onto the current scope.
+    #[deprecated]
     pub fn route<H>(&mut self, handler: H) -> Result<()>
+    where
+        H: Handler,
+        M: ModifyHandler<H>,
+        M::Handler: Into<C::Handler>,
+    {
+        self.route2(handler)
+    }
+
+    pub(crate) fn route2<H>(&mut self, handler: H) -> Result<()>
     where
         H: Handler,
         M: ModifyHandler<H>,
@@ -155,6 +167,7 @@ where
     }
 
     /// Creates a sub-scope with the provided prefix onto the current scope.
+    #[deprecated]
     pub fn mount(&mut self, prefix: impl AsRef<str>, config: impl Config<M, C>) -> Result<()> {
         let prefix: Uri = prefix.as_ref().parse().map_err(Error::custom)?;
 
@@ -183,6 +196,7 @@ where
     }
 
     /// Applies the specified configuration with a `ModifyHandler` on the current scope.
+    #[deprecated]
     pub fn modify<M2>(
         &mut self,
         modifier: M2,
@@ -223,7 +237,7 @@ where
         M::Handler: Into<C::Handler>,
     {
         let handler = RouteHandler::new(path.into_path(), endpoint);
-        self.route(modifier.modify(handler))
+        self.route2(modifier.modify(handler))
     }
 
     /// Adds a default route onto the current scope.

--- a/tsukuyomi/src/app/path.rs
+++ b/tsukuyomi/src/app/path.rs
@@ -1,5 +1,4 @@
 use {
-    super::Route,
     crate::{
         endpoint::Endpoint, //
         error::Error,
@@ -9,6 +8,9 @@ use {
     },
     std::{marker::PhantomData, sync::Arc},
 };
+
+#[allow(deprecated)]
+use crate::config::Route;
 
 #[doc(hidden)]
 pub use tsukuyomi_macros::path_impl;
@@ -62,10 +64,10 @@ where
 #[macro_export]
 macro_rules! path {
     ($path:expr) => {{
-        use $crate::config::path::internal as __path_internal;
+        use $crate::app::path::internal as __path_internal;
         enum __Dummy {}
         impl __Dummy {
-            $crate::config::path::path_impl!(__path_internal, $path);
+            $crate::app::path::path_impl!(__path_internal, $path);
         }
         __Dummy::call()
     }};
@@ -101,6 +103,8 @@ where
     }
 
     /// Creates a `Route` with this path configuration and the specified `Endpoint`.
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn to<T>(
         self,
         endpoint: T,

--- a/tsukuyomi/src/app/tests.rs
+++ b/tsukuyomi/src/app/tests.rs
@@ -152,3 +152,22 @@ fn current_thread() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn experimental_api() -> Result<()> {
+    let _app: App = App::build(|scope| {
+        scope.at("/", (), {
+            endpoint::reply("hello") //
+        })?;
+
+        scope.nest("/foo", (), |scope| {
+            scope.at(path!("/:id"), (), {
+                endpoint::call(|_id: u32| "got id") //
+            })
+        })?;
+
+        scope.default((), endpoint::reply("default")) //
+    })?;
+
+    Ok(())
+}

--- a/tsukuyomi/src/app/tests.rs
+++ b/tsukuyomi/src/app/tests.rs
@@ -1,22 +1,23 @@
 use {
     super::{config::Result, App},
-    crate::config::prelude::*,
+    crate::endpoint::builder as endpoint,
+    crate::path,
     matches::assert_matches,
 };
 
 #[test]
 fn new_empty() -> Result<()> {
-    let app = App::create(())?;
+    let app: App = App::build(|_s| Ok(()))?;
     assert_matches!(app.inner.find_endpoint("/", &mut None), Err(..));
     Ok(())
 }
 
 #[test]
 fn route_single_method() -> Result<()> {
-    let app = App::create(
-        path!("/") //
-            .to(endpoint::reply("")),
-    )?;
+    let app: App = App::build(|s| {
+        s.at("/", (), endpoint::reply(""))?;
+        Ok(())
+    })?;
 
     assert_matches!(
         app.inner.find_endpoint("/", &mut None),
@@ -35,14 +36,16 @@ fn route_single_method() -> Result<()> {
 
 #[test]
 fn scope_simple() -> Result<()> {
-    let app = App::create(chain![
-        mount("/").with(chain![
-            path!("/a").to(endpoint::reply("")),
-            path!("/b").to(endpoint::reply("")),
-        ]),
-        path!("/foo").to(endpoint::reply("")),
-        mount("/c").with(path!("/d").to(endpoint::reply(""))),
-    ])?;
+    let app: App = App::build(|s| {
+        s.nest("/", (), |s| {
+            s.at("/a", (), endpoint::reply(""))?;
+            s.at("/b", (), endpoint::reply(""))
+        })?;
+        s.at("/foo", (), endpoint::reply(""))?;
+        s.nest("/c", (), |s| {
+            s.at("/d", (), endpoint::reply("")) //
+        })
+    })?;
 
     assert_matches!(
         app.inner.find_endpoint("/a", &mut None),
@@ -66,23 +69,25 @@ fn scope_simple() -> Result<()> {
 
 #[test]
 fn scope_nested() -> Result<()> {
-    let app = App::create(chain![
-        mount("/") // 0
-            .with(chain![
-                path!("/foo").to(endpoint::reply("")), // /foo
-                path!("/bar").to(endpoint::reply("")), // /bar
-            ]),
-        mount("/baz") // 1
-            .with(chain![
-                path!("/").to(endpoint::reply("")), // /baz
-                mount("/") // 2
-                    .with(chain![
-                        path!("/foobar").to(endpoint::reply("")), // /baz/foobar
-                    ])
-            ]), //
-        path!("/hoge") //
-            .to(endpoint::reply("")) // /hoge
-    ])?;
+    let app: App = App::build(|s| {
+        // 0
+        s.nest("/", (), |s| {
+            s.at("/foo", (), endpoint::reply(""))?; // /foo
+            s.at("/bar", (), endpoint::reply("")) // /bar
+        })?;
+
+        // 1
+        s.nest("/baz", (), |s| {
+            s.at("/", (), endpoint::reply(""))?; // /baz
+
+            // 2
+            s.nest("/", (), |s| {
+                s.at("/foobar", (), endpoint::reply("")) // /baz/foobar
+            })
+        })?;
+
+        s.at("/hoge", (), endpoint::reply("")) // /hoge
+    })?;
 
     assert_matches!(
         app.inner.find_endpoint("/foo", &mut None),
@@ -116,39 +121,47 @@ fn scope_nested() -> Result<()> {
 
 #[test]
 fn failcase_duplicate_uri() -> Result<()> {
-    let app = App::create(chain![
-        path!("/path").to(endpoint::get().call(|| "")),
-        path!("/path").to(endpoint::allow_only("POST, PUT")?.call(|| "")),
-    ]);
-    assert!(app.is_err());
+    let res: Result<App> = App::build(|s| {
+        s.at("/path", (), {
+            endpoint::get().call(|| "") //
+        })?;
+        s.at("/path", (), {
+            endpoint::allow_only("POST, PUT")?.call(|| "") //
+        })
+    });
+    assert!(res.is_err());
     Ok(())
 }
 
 #[test]
 fn failcase_different_scope_at_the_same_uri() -> Result<()> {
-    let app = App::create(chain![
-        path!("/path") //
-            .to(endpoint::call(|| ""),),
-        mount("/").with(
-            path!("/path") //
-                .to(endpoint::post().call(|| ""))
-        )
-    ]);
-    assert!(app.is_err());
+    let res: Result<App> = App::build(|s| {
+        s.at("/path", (), {
+            endpoint::call(|| "") //
+        })?;
+        s.nest("/", (), |s| {
+            s.at("/path", (), {
+                endpoint::post().call(|| "") //
+            })
+        })
+    });
+    assert!(res.is_err());
     Ok(())
 }
 
 #[test]
 fn current_thread() -> Result<()> {
+    use super::concurrency::current_thread::CurrentThread;
     let ptr = std::rc::Rc::new(());
 
-    let _app = App::create_local(
-        path!("/") //
-            .to(endpoint::call(move || {
+    let _app: App<CurrentThread> = App::build(|s| {
+        s.at("/", (), {
+            endpoint::call(move || {
                 let _ptr = ptr.clone();
                 "dummy"
-            })),
-    )?;
+            })
+        })
+    })?;
 
     Ok(())
 }

--- a/tsukuyomi/src/config.rs
+++ b/tsukuyomi/src/config.rs
@@ -1,14 +1,26 @@
 //! A collection of components for configuring `App`.
 
-pub mod endpoint;
-pub mod path;
+#![deprecated(since = "0.6.0", note = "The old API will be removed at the next version.")]
+
+pub mod endpoint {
+    #[doc(inline)]
+    pub use crate::endpoint::builder::*;
+}
+
+pub mod path {
+    #[doc(inline)]
+    pub use crate::app::path::{Path, PathExtractor};
+}
 
 pub mod prelude {
     #[doc(no_inline)]
     pub use crate::{chain, path};
 
     #[doc(no_inline)]
-    pub use super::{mount, Config, ConfigExt};
+    pub use super::Config;
+    #[allow(deprecated)]
+    #[doc(no_inline)]
+    pub use super::{mount, ConfigExt};
 
     pub mod endpoint {
         #[doc(no_inline)]
@@ -22,13 +34,17 @@ pub mod prelude {
 #[doc(no_inline)]
 pub use crate::app::config::{Config, Error, IsConfig, Result, Scope};
 
-use crate::{
-    app::concurrency::Concurrency,
-    handler::{Handler, ModifyHandler},
-    util::Chain,
+use {
+    crate::{
+        app::concurrency::Concurrency,
+        handler::{Handler, ModifyHandler},
+        util::Chain,
+    },
+    std::fmt,
 };
 
 /// Creates a `Config` that creates a sub-scope with the provided prefix.
+#[allow(deprecated)]
 pub fn mount<P>(prefix: P) -> Mount<P, ()>
 where
     P: AsRef<str>,
@@ -37,12 +53,26 @@ where
 }
 
 /// A `Config` that registers a sub-scope with a specific prefix.
-#[derive(Debug)]
 pub struct Mount<P, T> {
     prefix: P,
     config: T,
 }
 
+#[allow(deprecated)]
+impl<P, T> fmt::Debug for Mount<P, T>
+where
+    P: fmt::Debug,
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Mount")
+            .field("prefix", &self.prefix)
+            .field("config", &self.config)
+            .finish()
+    }
+}
+
+#[allow(deprecated)]
 impl<P, T> Mount<P, T>
 where
     P: AsRef<str>,
@@ -55,6 +85,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<P, T> IsConfig for Mount<P, T>
 where
     P: AsRef<str>,
@@ -62,6 +93,7 @@ where
 {
 }
 
+#[allow(deprecated)]
 impl<P, T, M, C> Config<M, C> for Mount<P, T>
 where
     P: AsRef<str>,
@@ -76,19 +108,35 @@ where
 }
 
 /// Crates a `Config` that wraps a config with a `ModifyHandler`.
+#[allow(deprecated)]
 pub fn modify<M, T>(modifier: M, config: T) -> Modify<M, T> {
     Modify { modifier, config }
 }
 
 /// A `Config` that wraps a config with a `ModifyHandler`.
-#[derive(Debug)]
 pub struct Modify<M, T> {
     modifier: M,
     config: T,
 }
 
+#[allow(deprecated)]
+impl<M, T> fmt::Debug for Modify<M, T>
+where
+    M: fmt::Debug,
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Modify")
+            .field("modifier", &self.modifier)
+            .field("config", &self.config)
+            .finish()
+    }
+}
+
+#[allow(deprecated)]
 impl<M, T> IsConfig for Modify<M, T> where T: IsConfig {}
 
+#[allow(deprecated)]
 impl<M, T, M2, C> Config<M2, C> for Modify<M, T>
 where
     T: for<'a> Config<Chain<&'a M2, M>, C>,
@@ -102,6 +150,7 @@ where
 }
 
 /// A set of extension methods for constructing the complex `Config`.
+#[allow(deprecated)]
 pub trait ConfigExt: IsConfig + Sized {
     /// Creates a `Config` that applies `Self` and the specified configuration in order.
     fn chain<T>(self, next: T) -> Chain<Self, T>
@@ -118,14 +167,27 @@ pub trait ConfigExt: IsConfig + Sized {
     }
 }
 
+#[allow(deprecated)]
 impl<T: IsConfig> ConfigExt for T {}
 
 /// A `Config` that registers a route into a scope.
-#[derive(Debug)]
 pub struct Route<H> {
-    handler: H,
+    pub(crate) handler: H,
 }
 
+#[allow(deprecated)]
+impl<H> fmt::Debug for Route<H>
+where
+    H: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Route")
+            .field("handler", &self.handler)
+            .finish()
+    }
+}
+
+#[allow(deprecated)]
 impl<H> Route<H>
 where
     H: Handler,
@@ -136,8 +198,10 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<H> IsConfig for Route<H> where H: Handler {}
 
+#[allow(deprecated)]
 impl<H, M, C> Config<M, C> for Route<H>
 where
     H: Handler,

--- a/tsukuyomi/src/config/path.rs
+++ b/tsukuyomi/src/config/path.rs
@@ -28,6 +28,34 @@ impl PathExtractor for () {
     }
 }
 
+pub trait IntoPath {
+    type Output: Tuple;
+    type Extractor: PathExtractor<Output = Self::Output>;
+
+    fn into_path(self) -> Path<Self::Extractor>;
+}
+
+impl IntoPath for &'static str {
+    type Output = ();
+    type Extractor = ();
+
+    fn into_path(self) -> Path<Self::Extractor> {
+        Path::new(self)
+    }
+}
+
+impl<T> IntoPath for Path<T>
+where
+    T: PathExtractor,
+{
+    type Output = T::Output;
+    type Extractor = T;
+
+    fn into_path(self) -> Path<Self::Extractor> {
+        self
+    }
+}
+
 /// A macro for generating the code that creates a [`Path`] from the provided tokens.
 ///
 /// [`Path`]: ./app/config/route/struct.Path.html
@@ -86,7 +114,27 @@ where
     where
         T: Endpoint<E::Output>,
     {
-        let Self { path, .. } = self;
+        Route {
+            handler: RouteHandler::new(self, endpoint),
+        }
+    }
+}
+
+#[doc(hidden)]
+#[allow(missing_debug_implementations)]
+pub struct RouteHandler<E, T> {
+    endpoint: Arc<T>,
+    metadata: Metadata,
+    _marker: PhantomData<E>,
+}
+
+impl<E, T> RouteHandler<E, T>
+where
+    E: PathExtractor,
+    T: Endpoint<E::Output>,
+{
+    pub(crate) fn new(path: Path<E>, endpoint: T) -> Self {
+        let Path { path, .. } = path;
         let endpoint = Arc::new(endpoint);
 
         let mut metadata = match path {
@@ -95,26 +143,47 @@ where
         };
         *metadata.allowed_methods_mut() = endpoint.allowed_methods();
 
-        Route {
-            handler: crate::handler::handler(
-                move || self::handle::RouteHandle::new(endpoint.clone()),
-                metadata,
-            ),
+        Self {
+            endpoint,
+            metadata,
+            _marker: PhantomData,
         }
     }
 }
 
 mod handle {
     use {
-        super::PathExtractor,
+        super::{PathExtractor, RouteHandler},
         crate::{
             endpoint::{ApplyContext, Endpoint},
             error::Error,
             future::{Poll, TryFuture},
+            handler::{metadata::Metadata, Handler},
             input::Input,
         },
         std::{marker::PhantomData, sync::Arc},
     };
+
+    impl<E, T> Handler for RouteHandler<E, T>
+    where
+        E: PathExtractor,
+        T: Endpoint<E::Output>,
+    {
+        type Output = T::Output;
+        type Error = Error;
+        type Handle = RouteHandle<E, T>;
+
+        fn handle(&self) -> Self::Handle {
+            RouteHandle {
+                state: RouteHandleState::Init(self.endpoint.clone()),
+                _marker: PhantomData,
+            }
+        }
+
+        fn metadata(&self) -> Metadata {
+            self.metadata.clone()
+        }
+    }
 
     #[doc(hidden)]
     #[allow(missing_debug_implementations)]
@@ -125,19 +194,6 @@ mod handle {
     {
         state: RouteHandleState<T, T::Future>,
         _marker: PhantomData<E>,
-    }
-
-    impl<E, T> RouteHandle<E, T>
-    where
-        E: PathExtractor,
-        T: Endpoint<E::Output>,
-    {
-        pub fn new(endpoint: Arc<T>) -> Self {
-            Self {
-                state: RouteHandleState::Init(endpoint),
-                _marker: PhantomData,
-            }
-        }
     }
 
     #[allow(missing_debug_implementations)]

--- a/tsukuyomi/src/endpoint.rs
+++ b/tsukuyomi/src/endpoint.rs
@@ -1,5 +1,7 @@
 //! Definition of `Endpoint`.
 
+pub mod builder;
+
 use {
     crate::{error::Error, future::TryFuture, handler::metadata::AllowedMethods, input::Input},
     http::{Method, StatusCode},

--- a/tsukuyomi/src/endpoint/builder.rs
+++ b/tsukuyomi/src/endpoint/builder.rs
@@ -15,7 +15,7 @@ pub fn any() -> Builder {
     Builder::allow_any()
 }
 
-pub fn allow_only(methods: impl TryInto<AllowedMethods>) -> super::Result<Builder> {
+pub fn allow_only(methods: impl TryInto<AllowedMethods>) -> crate::app::config::Result<Builder> {
     Builder::allow_only(methods)
 }
 
@@ -67,10 +67,12 @@ impl Builder {
     }
 
     /// Creates a `Builder` that accepts only the specified HTTP methods.
-    pub fn allow_only(methods: impl TryInto<AllowedMethods>) -> super::Result<Self> {
+    pub fn allow_only(methods: impl TryInto<AllowedMethods>) -> crate::app::config::Result<Self> {
         Ok(Self {
             extractor: (),
-            allowed_methods: methods.try_into().map_err(super::Error::custom)?,
+            allowed_methods: methods
+                .try_into()
+                .map_err(crate::app::config::Error::custom)?,
         })
     }
 }

--- a/tsukuyomi/src/fs.rs
+++ b/tsukuyomi/src/fs.rs
@@ -558,7 +558,7 @@ where
 
             let file_type = entry.file_type().map_err(crate::config::Error::custom)?;
             if file_type.is_file() {
-                scope.route(ServeFile {
+                scope.route2(ServeFile {
                     inner: Arc::new(ServeFileInner {
                         path,
                         config: config.clone(),
@@ -569,7 +569,7 @@ where
                     }),
                 })?;
             } else if file_type.is_dir() {
-                scope.route(ServeFile {
+                scope.route2(ServeFile {
                     inner: Arc::new(ServeFileInner {
                         path,
                         config: config.clone(),

--- a/tsukuyomi/tests/cases/fs.rs
+++ b/tsukuyomi/tests/cases/fs.rs
@@ -1,5 +1,5 @@
 use tsukuyomi::{
-    config::prelude::*, //
+    endpoint::builder as endpoint,
     fs::{NamedFile, Staticfiles},
     App,
 };
@@ -7,16 +7,20 @@ use tsukuyomi::{
 #[test]
 #[ignore]
 fn compiletest() -> tsukuyomi::app::Result<()> {
-    App::create({
-        path!("/index.html") //
-            .to(endpoint::get() //
-                .reply(NamedFile::open("/path/to/index.html")))
+    App::build(|s| {
+        s.at("/index.html", (), {
+            endpoint::get() //
+                .reply(NamedFile::open("/path/to/index.html"))
+        })
     })
-    .map(drop)
+    .map(|_: App| ())
 }
 
 #[test]
 #[ignore]
 fn compiletest_staticfiles() -> tsukuyomi::app::Result<()> {
-    App::create(Staticfiles::new("./public")).map(drop)
+    App::build(|s| {
+        s.add(Staticfiles::new("./public")) //
+    })
+    .map(|_: App| ())
 }

--- a/tsukuyomi/tests/cases/into_response.rs
+++ b/tsukuyomi/tests/cases/into_response.rs
@@ -1,7 +1,7 @@
 use {
     http::{header, StatusCode},
     tsukuyomi::{
-        config::prelude::*, //
+        endpoint::builder as endpoint,
         test::{self, loc, TestServer},
         App,
     },
@@ -72,13 +72,10 @@ fn test_into_response_preset() -> test::Result {
         }
     }
 
-    let app = App::create(chain! {
-        path!("/foo") //
-            .to(endpoint::call(|| Foo("Foo".into()))),
-        path!("/bar") //
-            .to(endpoint::call(|| Bar("Bar")))
+    let app = App::build(|s| {
+        s.at("/foo", (), endpoint::call(|| Foo("Foo".into())))?;
+        s.at("/bar", (), endpoint::call(|| Bar("Bar")))
     })?;
-
     let mut server = TestServer::new(app)?;
     let mut client = server.connect();
 


### PR DESCRIPTION
The goal is to introduce the new API for building `App` so that it is easy to understand, and to resolve the following problems that the current API has:

* The current API using `Config` as a top-level abstraction is *overly* inclined to making Web application as *configurable* components.  There are actually *no* benefits to this approach, and instead, it became imperative to understand the extra helpers, even when writing *simple* applications.
* By using `Config` as a top-level abstraction of Web application written by the user, the information gained from the compile error became significantly reduced. The user needs to identify the wrong line based on only the information like `<...> doesn't implement Config<(), C>`. This is *obviously* lacking of ergonomics.

This PR adds the template of new API and deprecates the existing API. However, the old API might be removed before releasing 0.6.0.